### PR TITLE
[FIX] Still work in cases where no 'env' is there

### DIFF
--- a/base_domain_operator/expression.py
+++ b/base_domain_operator/expression.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # © 2017 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import threading
 from openerp import api
 # pylint: disable=W0402
 from openerp.osv.expression import ExtendedLeaf, expression, is_operator,\
     is_leaf
+from openerp.modules.registry import RegistryManager
 
 
 class BaseDomainOperatorExtendedLeaf(ExtendedLeaf):
@@ -52,11 +54,11 @@ def is_leaf_base_domain_operator(element, internal=False):
             isinstance(element, tuple) or isinstance(element, list)
     ) and len(element) > 1:
         # see if we have an environment with this operator
-        for env in api.Environment.envs:
-            if 'base.domain.operator' in env.registry:
-                result = hasattr(
-                    env['base.domain.operator'],
-                    '_operator_%s' % element[1].replace(' ', '_')
-                )
-            break
+        dbname = threading.current_thread().dbname
+        registry = RegistryManager.get(dbname)
+        if 'base.domain.operator' in registry:
+            result = hasattr(
+                registry['base.domain.operator'],
+                '_operator_%s' % element[1].replace(' ', '_')
+            )
     return result


### PR DESCRIPTION
I ran into a case whereby a search on `account.analytic.plan` is called from web and no `env` is there, traceback being:

```
Traceback (most recent call last):
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 546, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 583, in dispatch
    result = self._call_function(**self.params)
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 319, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 316, in checked_call
    return self.endpoint(*a, **kw)
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 812, in __call__
    return self.method(*args, **kw)
  File "/home/vwon/odoo/parts/odoo/openerp/http.py", line 412, in response_wrap
    response = f(*args, **kw)
  File "/home/vwon/odoo/parts/odoo/addons/web/controllers/main.py", line 944, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/vwon/odoo/parts/server-tools/server_monitoring/models/server_monitor_process.py", line 92, in _call_kw
    result = orig_call_kw(self, model, method, args, kwargs)
  File "/home/vwon/odoo/parts/odoo/addons/web/controllers/main.py", line 936, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/addons/account_analytic_plans/account_analytic_plans.py", line 131, in search
    context=context, count=count)
  File "/home/vwon/odoo/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/models.py", line 1690, in search
    return self._search(cr, user, args, offset=offset, limit=limit, order=order, context=context, count=count)
  File "/home/vwon/odoo/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/models.py", line 4773, in _search
    query = self._where_calc(cr, user, args, context=context)
  File "/home/vwon/odoo/parts/odoo/openerp/api.py", line 268, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/vwon/odoo/parts/odoo/openerp/models.py", line 4579, in _where_calc
    e = expression.expression(cr, user, domain, self, context)
  File "/home/vwon/odoo/parts/odoo/openerp/osv/expression.py", line 659, in __init__
    self.expression = distribute_not(normalize_domain(exp))
  File "/home/vwon/odoo/parts/odoo/openerp/osv/expression.py", line 308, in distribute_not
    elif token in DOMAIN_OPERATORS_NEGATION:
TypeError: unhashable type: 'list'
```

This solves the issue, I hope I did the right thing.